### PR TITLE
Updated to latest version of chartist and enable a way to add listener to chartist events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+*.iml
+.idea

--- a/index.js
+++ b/index.js
@@ -15,7 +15,17 @@ var ChartistGraph = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
-    return this.updateChart(newProps);
+    this.updateChart(newProps);
+  },
+
+  componentWillUnmount: function() {
+    if (this.chartist) {
+      try {
+        this.chartist.detach();
+      } catch (err) {
+
+      }
+    }
   },
 
   updateChart: function(config) {
@@ -23,14 +33,42 @@ var ChartistGraph = React.createClass({
     var data = config.data
     var options = config.options || {}
     var responsiveOptions = config.responsiveOptions || []
-    return new Chartist[type](this.getDOMNode(), data, options, responsiveOptions);
+    var event;
+
+    
+    if (this.chartist) {
+      //this sometimes cause some error internal within chartist.
+      try {
+        this.chartist.detach();
+      } catch (err) {
+
+      }
+    }
+    this.chartist = new Chartist[type](this.getDOMNode(), data, options, responsiveOptions);
+
+    //register event handlers
+    /**
+     * listeners: {
+     *   draw : function() {}
+     * } 
+     */
+    if (config.listener) {
+      for (event in config.listener) {
+        if (config.listener.hasOwnProperty(event)) {
+          this.chartist.on(event, config.listener[event]);
+        }
+      }
+    }
+    //return
+    return this.chartist;
+
   },
 
   componentDidMount: function() {
     return this.updateChart(this.props);
   },
 
-  render: function() {
+  render: function () {
     return React.DOM.div({className: 'ct-chart'})
   }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": ">=0.10.0"
   },
   "dependencies": {
-    "chartist": "^0.3.1",
+    "chartist": "^0.7.1",
     "react": "^0.12.0"
   }
 }


### PR DESCRIPTION
Updated to latest version of chartist and enable a way to add listener to chartist events

```javascript

var listener = {
            
            draw : function(data) {
                if(data.type === 'bar') {
                    data.element.attr({
                        style: 'stroke-width: 20px'
                    });
                }
            }
        };

<ChartistGraph data={} listener={listener} type={'Bar'} options={ { axisY: { offset: 120 }, reverseData:true, horizontalBars : true } }/>
```