### PR TITLE
added a way to add listeners view props and updated chartist to 0.7.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,16 @@ var ChartistGraph = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
-    return this.updateChart(newProps);
+    this.updateChart(newProps);
+  },
+
+  componentWillUnmount: function() {
+    if (this.chartist) {
+      try {
+        this.chartist.detach();
+      } catch (err) {
+      }
+    }
   },
 
   updateChart: function(config) {
@@ -23,7 +32,35 @@ var ChartistGraph = React.createClass({
     var data = config.data
     var options = config.options || {}
     var responsiveOptions = config.responsiveOptions || []
-    return new Chartist[type](this.getDOMNode(), data, options, responsiveOptions);
+    var event;
+
+    
+    if (this.chartist) {
+      //this sometimes cause some error internal within chartist.
+      try {
+        this.chartist.detach();
+      } catch (err) {
+
+      }
+    }
+    this.chartist = new Chartist[type](this.getDOMNode(), data, options, responsiveOptions);
+
+    //register event handlers
+    /**
+     * listeners: {
+     *   draw : function() {}
+     * } 
+     */
+    if (config.listener) {
+      for (event in config.listener) {
+        if (config.listener.hasOwnProperty(event)) {
+          this.chartist.on(event, config.listener[event]);
+        }
+      }
+    }
+    //return
+    return this.chartist;
+
   },
 
   componentDidMount: function() {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": ">=0.10.0"
   },
   "dependencies": {
-    "chartist": "^0.3.1",
+    "chartist": "^0.7.1",
     "react": "^0.12.0"
   }
 }


### PR DESCRIPTION
Updated to latest version of chartist and enable a way to add listener to chartist events

```javascript

var listener = {
            
            draw : function(data) {
                if(data.type === 'bar') {
                    data.element.attr({
                        style: 'stroke-width: 20px'
                    });
                }
            }
        };

<ChartistGraph data={} listener={listener} type={'Bar'} options={ { axisY: { offset: 120 }, reverseData:true, horizontalBars : true } }/>
```