### PR TITLE
Allow aspect ratio to be passed as attribute.

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ var ChartistGraph = React.createClass({
   },
 
   render: function() {
-    return React.DOM.div({className: 'ct-chart'})
+    return React.DOM.div({className: 'ct-chart ' + this.props.className});
   }
 
 });

--- a/index.js
+++ b/index.js
@@ -73,4 +73,7 @@ var ChartistGraph = React.createClass({
 
 });
 
-module.exports = ChartistGraph
+module.exports = {
+    'ChartistGraph': ChartistGraph,
+    'Chartist': Chartist
+};


### PR DESCRIPTION
This commit allows one to pass in an aspect ratio without breaking existing code, but I wonder if it
would be better to follow the original Chartist API and require ChartListGraph to be created with:

 `return <ChartistGraph className='ct-chart' data={data} type={type} />`

Or if you want to specify an aspect ratio:

`return <ChartistGraph className='ct-chart ct-octave' data={data} type={type} />`
    