### PR TITLE
Delegate update to chartist

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,26 +31,16 @@ class ChartistGraph extends React.Component {
     let responsiveOptions = config.responsiveOptions || [];
     let event;
 
-    if (this.chartist) {
-      //this sometimes cause some error internal within chartist.
-      try {
-        this.chartist.detach();
-      } catch (err) {
-        console.error('internal chartist error: ', err);
-      }
-    }
-    this.chartist = new Chartist[type](React.findDOMNode(this), data, options, responsiveOptions);
+   if (this.chartist) {
+      this.chartist.update(data, options, responsiveOptions)
+    } else {
+      this.chartist = new _Chartist2['default'][type](_React2['default'].findDOMNode(this), data, options, responsiveOptions);
 
-    //register event handlers
-    /**
-     * listeners: {
-     *   draw : function() {}
-     * }
-     */
-    if (config.listener) {
-      for (event in config.listener) {
-        if (config.listener.hasOwnProperty(event)) {
-          this.chartist.on(event, config.listener[event]);
+      if (config.listener) {
+        for (event in config.listener) {
+          if (config.listener.hasOwnProperty(event)) {
+            this.chartist.on(event, config.listener[event]);
+          }
         }
       }
     }


### PR DESCRIPTION
When new properties received, we don't have to re-create chartist object, we can simply delegate it to chartist.update()