### PR TITLE
Added isomorphic rendering support, added Chartist as a peer dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 
 import React from 'react';
-import Chartist from 'chartist';
 
 class ChartistGraph extends React.Component {
 
@@ -26,6 +25,8 @@ class ChartistGraph extends React.Component {
   }
 
   updateChart(config) {
+    let Chartist = require('chartist');
+
     let { type, data } = config;
     let options = config.options || {};
     let responsiveOptions = config.responsiveOptions || [];

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "react": ">=0.13.0"
+    "react": ">=0.13.0",
+    "chartist": ">=0.9.0"
   },
   "dependencies": {
-    "chartist": "^0.8.0",
+    "chartist": "^0.9.1",
     "react": "^0.13.2"
   },
   "scripts": {


### PR DESCRIPTION
One of the great things about React is the ability to run code on both the client and server-side. Chartist doesn't support this because it's a client-side library. There should still be a way to include this component in server-side code, though. If you currently try to run this in the server context, an error is thrown when calling `require('chartist')`. This PR moves the `require` call into `updateChart`, which will never be called on the server-side. (because it's being called by methods that aren't run on the server-side, see [this link](https://facebook.github.io/react/docs/component-specs.html).)

Another change in this PR is the addition of Chartist as a peer dependency. By adding it as a peer dependency, we don't have to wait for a PR to be submitted into this repo to update Chartist. I also updated the Chartist version number to the latest version. 