### PR TITLE
Support React 0.14

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
 
-import React from 'react';
+import React, {Component} from 'react';
+import {findDOMNode} from 'react-dom';
 
-class ChartistGraph extends React.Component {
+class ChartistGraph extends Component {
 
   displayName: 'ChartistGraph'
 
@@ -35,7 +36,7 @@ class ChartistGraph extends React.Component {
     if (this.chartist) {
       this.chartist.update(data, options, responsiveOptions);
     } else {
-      this.chartist = new Chartist[type](React.findDOMNode(this), data, options, responsiveOptions);
+      this.chartist = new Chartist[type](findDOMNode(this), data, options, responsiveOptions);
 
       if (config.listener) {
         for (event in config.listener) {
@@ -51,8 +52,8 @@ class ChartistGraph extends React.Component {
   }
 
   render() {
-    let className = this.props.className ? ' ' + this.props.className : ''
-    return React.DOM.div({className: 'ct-chart' + className})
+    const className = this.props.className ? ' ' + this.props.className : ''
+    return (<div className={'ct-chart' + className} />)
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "react": ">=0.13.0",
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "chartist": ">=0.9.0"
   },
   "dependencies": {
-    "chartist": "^0.9.4",
-    "react": "^0.13.2"
+    "chartist": "^0.9.4"
   },
   "scripts": {
     "build": "mkdir -p dist && babel index.js > dist/index.js"


### PR DESCRIPTION
##### Changes

* Update component to use ReactDOM if using React 0.14
* Update package.json not to install react (fixes issues with e.g., webpack)

##### Rationale

Currently, trying to use the react-chartist comopnent in a React 0.14 project causes a fatal error

```
Error: Invariant Violation: ChartistGraph.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object.
```

This is because there are two versions of React loaded (0.13 from this project and 0.14 from main project).

Additionally, even if you are not using a commonjs bundler (e.g., manually including libraries from CDN in your html), all DOM-related functions have been moved to ReactDOM.  This required a couple minor changes to the component itself.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/fraserxu/react-chartist/24)
<!-- Reviewable:end -->
