### PR TITLE
Don't do any re-rendering if no props have changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,17 @@ class ChartistGraph extends Component {
 
   displayName: 'ChartistGraph'
 
-  componentWillReceiveProps(newProps) {
+  shouldComponentUpdate(newProps) {
+    const { data, className, type, options, style, responsiveOptions } = this.props;
+    return data !== newProps.data
+      || className !== newProps.className
+      || type !== newProps.type
+      || options !== newProps.options
+      || style !== newProps.style
+      || responsiveOptions !== newProps.responsiveOptions;
+  }
+
+  componentWillUpdate(newProps) {
     this.updateChart(newProps);
   }
 


### PR DESCRIPTION
If a parent component re-renders, it triggers this component to re-render. If none of the props have changed, don't do any re-rendering to improve performance.
