### PR TITLE
feat(package): chartist 0.10 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0-0"
   },
-  "dependencies": {
-    "chartist": "^0.9.4"
-  },
   "scripts": {
     "build": "mkdir -p dist && babel index.js > dist/index.js"
   },
@@ -38,5 +35,8 @@
     "babelify": "^5.0.3",
     "browserify": "^8.1.0",
     "watchify": "^2.2.1"
+  },
+  "peerDependencies": {
+    "chartist": "^0.10.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
+    "chartist": "^0.10.1",
     "react": "^0.14.0 || ^15.0.0-0"
   },
   "scripts": {
@@ -35,8 +36,5 @@
     "babelify": "^5.0.3",
     "browserify": "^8.1.0",
     "watchify": "^2.2.1"
-  },
-  "peerDependencies": {
-    "chartist": "^0.10.1"
   }
 }


### PR DESCRIPTION
BREAKING: as chartist is no longer a solid dependency, it's necessary for react-chartist users to depend on it directly.

react-chartist version should be bumped to 0.11.0.

Replace both #42 and #43.