### PR TITLE
Replace React.PropTypes with the new standalone PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import React, { Component, cloneElement, Children } from 'react';
+import PropTypes from 'prop-types'
 
 class ChartistGraph extends Component {
 
@@ -64,12 +65,12 @@ class ChartistGraph extends Component {
 }
 
 ChartistGraph.propTypes = {
-  type: React.PropTypes.oneOf(['Line', 'Bar', 'Pie']).isRequired,
-  data: React.PropTypes.object.isRequired,
-  className: React.PropTypes.string,
-  options: React.PropTypes.object,
-  responsiveOptions: React.PropTypes.array,
-  style: React.PropTypes.object
+  type: PropTypes.oneOf(['Line', 'Bar', 'Pie']).isRequired,
+  data: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  options: PropTypes.object,
+  responsiveOptions: PropTypes.array,
+  style: PropTypes.object
 }
 
 export default ChartistGraph;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
     "chartist": "^0.10.1",
-    "react": "^0.14.0 || ^15.0.0-0"
+    "react": "^0.14.9 || ^15.3.0"
   },
   "scripts": {
     "build": "mkdir -p dist && babel index.js -o dist/index.js"

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.8"
   }
 }


### PR DESCRIPTION
This should prevent the warning`Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.`, when using react-chartist with React v15.3 and above.