### PR TITLE
Allow any chartist version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "chartist": "^0.10.1 || ^0.11.0",
+    "chartist": ">=0.9.4",
     "react": "^0.14.9 || ^15.3.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "chartist": "^0.10.1",
+    "chartist": "^0.10.1 || ^0.11.0",
     "react": "^0.14.9 || ^15.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Allow the consumer to have flexibility with the version of the chartist library.

In my case, there is a regression above 0.9.4 that prevents me from upgrading.