### PR TITLE
Bump chartist peer dependency to ^0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "chartist": "^0.10.1",
+    "chartist": "^0.10.1 || ^0.11.0",
     "react": "^0.14.9 || ^15.3.0"
   },
   "scripts": {


### PR DESCRIPTION
Now the main chartist lib has 0.11.0 version, so, installation of `react-chartist` cause ` UNMET PEER DEPENDENCY` warning. This PR fixes this.