### PR TITLE
Add new `forceRecreation` prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,9 +31,17 @@ class ChartistGraph extends Component {
     let responsiveOptions = config.responsiveOptions || [];
     let event;
 
-    if (this.chartist) {
+    if (this.chartist && !config.forceRecreation) {
       this.chartist.update(data, options, responsiveOptions);
     } else {
+      if (this.chartist && config.listener && config.forceRecreation) {
+        for (event in config.listener) {
+          if (config.listener.hasOwnProperty(event)) {
+            this.chartist.off(event, config.listener[event]);
+          }
+        }
+      }
+      
       this.chartist = new Chartist[type](this.chart, data, options, responsiveOptions);
 
       if (config.listener) {
@@ -69,6 +77,8 @@ ChartistGraph.propTypes = {
   data: PropTypes.object.isRequired,
   className: PropTypes.string,
   options: PropTypes.object,
+  listener: PropTypes.object,
+  forceRecreation: PropTypes.bool,
   responsiveOptions: PropTypes.array,
   style: PropTypes.object
 }


### PR DESCRIPTION
I faced with an issue when `updateChart()` method doesn't work properly.
Assume we have a component that needs to pass additional arguments to Chartist listener using `bind`. Like in this example

```
import ChartistGraph from 'react-chartist';

export default class ComplexComponent extends React.PureComponent {
  chartDrawHandler(info, data) {
    var pointShape = getPointShape(info[data.index], data);
    // continue
  }

  render() {
    var listener = {
      draw: this.chartDrawHandler.bind(this, info)
    };

    return (
      <ChartistGraph listener={listener}/>
    )
  }
}
```

In the current implementation, `react-chartist` component binds additional data to listeners only once, when the new chart instance is created. But in the above example, we need to bind new data to listener each time when `render()` method of the `ComplexComponent` is called.

To fix this issue I added new `forceRecreation` boolean prop to `react-chartist` component. If this prop has a true value, we unbind all listeners from the existing instance of Chartist graph and create the new instance of it from scratch in each call of `updateChart()` method.