### PR TITLE
Added check for chart type on update.

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class ChartistGraph extends Component {
     let responsiveOptions = config.responsiveOptions || [];
     let event;
 
-    if (this.chartist) {
+    if (this.chartist && this.chartist instanceof Chartist[type]) {
       this.chartist.update(data, options, responsiveOptions);
     } else {
       this.chartist = new Chartist[type](this.chart, data, options, responsiveOptions);


### PR DESCRIPTION
I have a use case where I need to dynamically change the chart type, which would require re-rendering the chart. However, the `updateChart()` method only factors in data and options changes after the initial creation of a chart. The attached PR checks to see if the current instance is the same type as the current value of `type` and, if not, creates a new Chartist instance. 