### PR TITLE
Add missing props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,8 @@ export interface ChartitGraphProps {
   data: object;
   className?: string;
   options?: IChartOptions;
+  listener?: any;
+  responsiveOptions?: any;
   style?: React.CSSProperties;
 }
 


### PR DESCRIPTION
This fixes compilation problem with typescript when using listener props for animation for example...