### PR TITLE
Fixed TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,37 +1,48 @@
-import { ChartitGraphProps } from './index.d';
-import * as React from 'react';
+import * as React from 'react'
+
 import {
-  IChartOptions,
-  IResponsiveOptionTuple,
-  ILineChartOptions,
   IBarChartOptions,
+  ICandleChartOptions,
+  IChartOptions,
+  ILineChartOptions,
   IPieChartOptions,
-} from 'chartist';
+  IResponsiveOptionTuple,
+} from 'chartist'
 
-export interface ChartitGraphProps {
-  type: string;
-  data: object;
-  className?: string;
-  options?: IChartOptions;
-  style?: React.CSSProperties;
+export type ChartistListenerOptions = {[key: string]: Function}
+
+interface BaseChartistGraphProps {
+  data: Object
+  className?: string
+  options?: IChartOptions
+  style?: React.CSSProperties
+  listener?: ChartistListenerOptions
 }
 
-export interface ChartitGraphLineProps extends ChartitGraphProps {
-  type: 'Line';
-  options?: ILineChartOptions;
-  responseOptions?: Array<IResponsiveOptionTuple<ILineChartOptions>>;
+export interface ChartistGraphBarProps extends BaseChartistGraphProps {
+  type: 'Bar'
+  options: IBarChartOptions
+  responsiveOptions?: Array<IResponsiveOptionTuple<IBarChartOptions>>
 }
 
-export interface ChartitGraphPieProps extends ChartitGraphProps {
-  type: 'Pie';
-  options?: IPieChartOptions;
-  responseOptions?: Array<IResponsiveOptionTuple<IPieChartOptions>>;
+export interface ChartistGraphCandleProps extends BaseChartistGraphProps {
+  type: 'Candle'
+  options: ICandleChartOptions
+  responsiveOptions?: Array<IResponsiveOptionTuple<ICandleChartOptions>>
 }
 
-export interface ChartitGraphBarProps extends ChartitGraphProps {
-  type: 'Bar';
-  options: IBarChartOptions;
-  responseOptions?: Array<IResponsiveOptionTuple<IBarChartOptions>>;
+export interface ChartistGraphLineProps extends BaseChartistGraphProps {
+  type: 'Line'
+  options?: ILineChartOptions
+  responsiveOptions?: Array<IResponsiveOptionTuple<ILineChartOptions>>
 }
 
-export default class ChartistGraph extends React.Component<ChartitGraphProps> {}
+export interface ChartistGraphPieProps extends BaseChartistGraphProps {
+  type: 'Pie'
+  options?: IPieChartOptions
+  responsiveOptions?: Array<IResponsiveOptionTuple<IPieChartOptions>>
+}
+
+export type ChartistGraphProps = ChartistGraphBarProps | ChartistGraphCandleProps | ChartistGraphLineProps | ChartistGraphPieProps
+
+export default class ChartistGraph extends React.Component<ChartistGraphProps> {}


### PR DESCRIPTION
* `Chartist` instead of `Chartit`
* `responsiveOptions` instead of `responseOptions`
* `listener` (not the best definition, but `chartist` itself doesn't even _document_ the events)
* Support for `Candle` graphs
* Correctly enforced props i.e. if the type is specified as `Line` then the options (if specified) must be `ILineChartOptions`.