### PR TITLE
Remove recursive self-import of ChartitGraphProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import { ChartitGraphProps } from './index.d';
 import * as React from 'react';
 import {
   IChartOptions,

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "@types/chartist": "^0.9.43"
+    "babel-preset-stage-0": "^6.16.0"
   },
   "dependencies": {
     "prop-types": "^15.5.8"


### PR DESCRIPTION
With TypeScript 3.7, that line causes the following error, preventing TypeScript from compiling successfully:

```
node_modules/react-chartist/dist/index.d.ts:1:10 - error TS2440: Import declaration conflicts with local declaration of 'ChartitGraphProps'.

1 import { ChartitGraphProps } from './index.d';
           ~~~~~~~~~~~~~~~~~

[7:11:32 PM] Found 1 error. Watching for file changes.
```

This resolves that error.