### PR TITLE
Update chart when props change

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,21 +3,7 @@ import PropTypes from 'prop-types'
 
 class ChartistGraph extends Component {
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      type: '',
-    }
-  }
-
   displayName: 'ChartistGraph'
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (nextProps.type !== prevState.type) {
-      return { ...nextProps }
-    }
-    return null;
-  }
 
   componentWillUnmount() {
     if (this.chartist) {
@@ -30,6 +16,10 @@ class ChartistGraph extends Component {
   }
 
   componentDidMount() {
+    this.updateChart(this.props);
+  }
+
+  componentDidUpdate() {
     this.updateChart(this.props);
   }
 
@@ -67,8 +57,8 @@ class ChartistGraph extends Component {
       })
     ));
     return (
-      <div className={`ct-chart ${className || ''}`} ref={(ref) => this.chart = ref } style={style}>
-         {childrenWithProps}
+      <div className={`ct-chart ${className || ''}`} ref={(ref) => this.chart = ref} style={style}>
+        {childrenWithProps}
       </div>
     )
   }


### PR DESCRIPTION
The 0.14 release of this library removed `componentWillReceiveProps` to address warnings from React that this is an unsafe method and will be removed in React 17.x. Unfortunately, this introduced a regression where `updateChart` is no longer called when props change. This PR restores that behavior while still satisfying the unsafe method warning by switching `getDerivedStateFromProps` to the `componentDidUpdate` lifecycle.

Related issues: #88 #84 #83 #73 