### PR TITLE
Allow react 17 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
     "chartist": "^0.10.1",
-    "react": "^0.14.9 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.9 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "scripts": {
     "build": "mkdir -p dist && babel index.js -o dist/index.js && cp index.d.ts dist/index.d.ts",


### PR DESCRIPTION
Hey there,

We are using react 17 and I believe the library should also work in this version, therefore I'd like to update the peer dependency requirement