### PR TITLE
Fix installation with chartist@0.11 using npm@7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/fraserxu/react-chartist",
   "peerDependencies": {
-    "chartist": "^0.10.1",
+    "chartist": "^0.10.1 || ^0.11.0",
     "react": "^0.14.9 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "scripts": {


### PR DESCRIPTION
I getting this error using npm@7 and I tried to fix your package, because your npm works properly with chartist@0.11.

But I'm not sure if this is the best way to declare the peerDep correctly.

```
npm ERR! Found: chartist@0.11.4
npm ERR! node_modules/chartist
npm ERR!   chartist@"^0.11.4" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer chartist@"^0.10.1" from react-chartist@0.14.4
npm ERR! node_modules/react-chartist
npm ERR!   react-chartist@"0.14.4" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```