### PR TITLE
Fix runtime error in example: Chartist[type] is not a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class Bar extends React.Component {
       }
     };
 
-    var type = 'Bar'
+    var type = 'BarChart'
 
     return (
       <div>


### PR DESCRIPTION
The Latest Chartist versions don't have a type Bar.

<img width="749" alt="Screenshot 2022-12-11 at 5 41 16 PM" src="https://user-images.githubusercontent.com/58985470/206943348-fea9c7fb-1b7c-490c-ae4f-c9f81bb5319b.png">
