### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,3 @@ jobs:
             dist_tag=latest
           fi
           npm publish --access public --provenance --tag "$dist_tag"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- remove the legacy `NPM_TOKEN` environment variable from the npm release job
- rely on the verified npm Trusted Publisher connection for `fraserxu/react-chartist` and `release.yml`

## Why

The package now uses GitHub Actions OIDC publishing. Keeping a token reference is unnecessary and would cause the release job to attempt token-based authentication even though no repository secret is configured.

## Validation

- npm Trusted Publisher verified in the package settings with `npm publish` permission
- release workflow YAML parsed successfully
- `npm run check`
- 6 tests passed
- ESM, CommonJS, and declaration builds passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to npm publish authentication; no application runtime or package API changes.
> 
> **Overview**
> The release workflow no longer passes **`NODE_AUTH_TOKEN`** from **`secrets.NPM_TOKEN`** on the **Publish to npm** step.
> 
> Publishing is expected to authenticate via **npm Trusted Publishing** (GitHub Actions OIDC), which aligns with the workflow’s existing **`id-token: write`** permission and **`setup-node`** registry configuration—avoiding token-based auth when no secret is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ced663be8da00ad9ab77faa7e431a02e3ab48bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->