### PR TITLE
Fix stale demo styles after Pages deploy

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/chartist@1.5.0/dist/index.css"
     />
-    <link rel="stylesheet" href="./style.css" />
+    <link rel="stylesheet" href="./style.css?v=1.0.1" />
     <script type="importmap">
       {
         "imports": {


### PR DESCRIPTION
## Summary
- version the demo stylesheet request to bypass the stale GitHub Pages edge/browser cache
- leave the demo assets and behavior unchanged

## Verification
- npm run check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single HTML cache-busting query string with no security, auth, or runtime behavior impact.
> 
> **Overview**
> Fixes **stale demo styling** after GitHub Pages deploys by appending a **version query** (`?v=1.0.1`) to the `./style.css` link in `docs/index.html`, so browsers and the Pages CDN fetch fresh CSS instead of a cached copy.
> 
> No demo logic or other assets change—only the stylesheet URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d390edc725b1e6cd48f009ef79496a4458d3bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->